### PR TITLE
Weak lock for json

### DIFF
--- a/moonrope-client.gemspec
+++ b/moonrope-client.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.summary     = "A client library for the the Moonrope API server."
   s.description = "A full client library allows requests to made to Moonrope-enabled API endpoints."
   s.files = Dir["{lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
-  s.add_dependency "json", "~> 1.8", ">= 1.8.0"
+  s.add_dependency "json", ">= 1.8.0"
   s.add_development_dependency 'yard', '~> 0.8', '>= 0.8.0'
   s.licenses    = ["MIT"]
 end


### PR DESCRIPTION
This allows to avoid some deprecation messages for applications which build on ruby 2.6.

https://github.com/flori/json/blob/master/CHANGES.md#2019-02-21-220